### PR TITLE
Use a computedProperty with get set.

### DIFF
--- a/addon/utils/is-fastboot.js
+++ b/addon/utils/is-fastboot.js
@@ -5,13 +5,22 @@ import ComputedProperty from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
 import ApplicationInstance from '@ember/application/instance';
+import { isPresent } from '@ember/utils';
 
 /**
  * @return {ComputedProperty<boolean>}
  */
 export default function isFastBootCPM() {
-  return computed(function() {
-    return isFastBoot(getOwner(this));
+  return computed({
+    get() {
+      if (isPresent(this._isFastBootCPM)) {
+        return this._isFastBootCPM;
+      }
+      return isFastBoot(getOwner(this));
+    },
+    set(key, value) {
+      return this._isFastBootCPM = value;
+    }
   });
 }
 


### PR DESCRIPTION
Since the _isFastBoot computedProperty is overridden in some places, I've used added a setter as per https://deprecations.emberjs.com/v3.x/#toc_computed-property-override